### PR TITLE
Changed postgres healthcheck user, since it was generating a Fatal error in docker logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     networks:
       - ndsnet
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U ngods"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
With the previous `pg_isready -U postgres`, the errror "FATAL:  role "postgres" does not exist" was generated